### PR TITLE
Indent nowdocs for readability

### DIFF
--- a/tests/HighlightAdapterTest.php
+++ b/tests/HighlightAdapterTest.php
@@ -28,20 +28,20 @@ class HighlightAdapterTest extends TestCase
     public function testHighlightAdapter()
     {
         $html = <<<'EOD'
-<pre><code class="language-css">.foo {
-    color: var(--bar);
-}</code></pre>
+        <pre><code class="language-css">.foo {
+            color: var(--bar);
+        }</code></pre>
 
-<pre><code class="language-js">export const foo = 'bar'</code></pre>
-EOD;
+        <pre><code class="language-js">export const foo = 'bar'</code></pre>
+        EOD;
 
         $expectedHtml = <<<'EOD'
-<pre class="hljs"><code><span class="hljs-selector-class">.foo</span> {
-    <span class="hljs-attribute">color</span>: <span class="hljs-built_in">var</span>(--bar);
-}</code></pre>
+        <pre class="hljs"><code><span class="hljs-selector-class">.foo</span> {
+            <span class="hljs-attribute">color</span>: <span class="hljs-built_in">var</span>(--bar);
+        }</code></pre>
 
-<pre class="hljs"><code><span class="hljs-keyword">export</span> <span class="hljs-keyword">const</span> foo = <span class="hljs-string">'bar'</span></code></pre>
-EOD;
+        <pre class="hljs"><code><span class="hljs-keyword">export</span> <span class="hljs-keyword">const</span> foo = <span class="hljs-string">'bar'</span></code></pre>
+        EOD;
 
         $this->assertEquals($expectedHtml, HighlightAdapter::highlight($html));
     }
@@ -49,23 +49,23 @@ EOD;
     public function testKirbytextExplicitHighlighting()
     {
         $text = <<<'EOD'
-```css
-.foo {
-    color: var(--bar);
-}
-```
+        ```css
+        .foo {
+            color: var(--bar);
+        }
+        ```
 
-```js
-export const foo = 'bar'
-```
-EOD;
+        ```js
+        export const foo = 'bar'
+        ```
+        EOD;
 
         $expectedHtml = <<<'EOD'
-<pre class="hljs"><code><span class="hljs-selector-class">.foo</span> {
-    <span class="hljs-attribute">color</span>: <span class="hljs-built_in">var</span>(--bar);
-}</code></pre>
-<pre class="hljs"><code><span class="hljs-keyword">export</span> <span class="hljs-keyword">const</span> foo = <span class="hljs-string">'bar'</span></code></pre>
-EOD;
+        <pre class="hljs"><code><span class="hljs-selector-class">.foo</span> {
+            <span class="hljs-attribute">color</span>: <span class="hljs-built_in">var</span>(--bar);
+        }</code></pre>
+        <pre class="hljs"><code><span class="hljs-keyword">export</span> <span class="hljs-keyword">const</span> foo = <span class="hljs-string">'bar'</span></code></pre>
+        EOD;
 
         $this->assertEquals($expectedHtml, $this->kirby->kirbytext($text));
     }
@@ -73,22 +73,22 @@ EOD;
     public function testKirbytextSkipHighlighting()
     {
         $text = <<<'EOD'
-```
-.foo {
-    color: var(--bar);
-}
-```
+        ```
+        .foo {
+            color: var(--bar);
+        }
+        ```
 
-```js
-export const foo = 'bar'
-```
-EOD;
+        ```js
+        export const foo = 'bar'
+        ```
+        EOD;
         $expectedHtml = <<<'EOD'
-<pre><code>.foo {
-    color: var(--bar);
-}</code></pre>
-<pre class="hljs"><code><span class="hljs-keyword">export</span> <span class="hljs-keyword">const</span> foo = <span class="hljs-string">'bar'</span></code></pre>
-EOD;
+        <pre><code>.foo {
+            color: var(--bar);
+        }</code></pre>
+        <pre class="hljs"><code><span class="hljs-keyword">export</span> <span class="hljs-keyword">const</span> foo = <span class="hljs-string">'bar'</span></code></pre>
+        EOD;
 
         $this->assertEquals($expectedHtml, $this->kirby->kirbytext($text));
     }
@@ -102,23 +102,23 @@ EOD;
         ]);
 
         $text = <<<'EOD'
-```
-.foo {
-    color: var(--bar);
-}
-```
+        ```
+        .foo {
+            color: var(--bar);
+        }
+        ```
 
-```js
-export const foo = 'bar'
-```
-EOD;
+        ```js
+        export const foo = 'bar'
+        ```
+        EOD;
 
         $expectedHtml = <<<'EOD'
-<pre class="hljs"><code><span class="hljs-selector-class">.foo</span> {
-    <span class="hljs-attribute">color</span>: <span class="hljs-built_in">var</span>(--bar);
-}</code></pre>
-<pre class="hljs"><code><span class="hljs-keyword">export</span> <span class="hljs-keyword">const</span> foo = <span class="hljs-string">'bar'</span></code></pre>
-EOD;
+        <pre class="hljs"><code><span class="hljs-selector-class">.foo</span> {
+            <span class="hljs-attribute">color</span>: <span class="hljs-built_in">var</span>(--bar);
+        }</code></pre>
+        <pre class="hljs"><code><span class="hljs-keyword">export</span> <span class="hljs-keyword">const</span> foo = <span class="hljs-string">'bar'</span></code></pre>
+        EOD;
 
         $this->assertEquals($expectedHtml, $app->kirbytext($text));
     }


### PR DESCRIPTION
Since PHP 7.3, heredocs and nowdocs can be indented; see https://wiki.php.net/rfc/flexible_heredoc_nowdoc_syntaxes. This greatly improves readability of the test file.

Because this plugin requires PHP 7.4+ as mentioned in the readme, it shouldn't be a problem that this feature is supported only in PHP 7.3+.