### PR TITLE
Feature/line numbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ To enable automatic language detection, set:
 | `kirby-extended.highlighter.class` | `hljs` | Style class for Highlight to be added to the `pre` element. |
 | `kirby-extended.highlighter.autodetect` | `false` | Indicates if the library should define which language thinks is best. Only applies when no language was set on the KirbyText code block. |
 | `kirby-extended.highlighter.languages` | `[]` | Array of language names to be auto-detected. If empty, every language will be auto-detectable. |
+|`kirby-extended.highlighter.line-numbering` | `false` | Indicates if the library should split up the highlighted code on each new line and wrap each line with a `<span>` element. |
+|`kirby-extended.highlighter.line-numbering-class` | `code-line` | Style class applied to highlighted code line `<span>` elements.|
 
 ## Styling in the frontend
 
@@ -81,6 +83,24 @@ The CSS files over at the repository are maintained and new ones arrive from tim
 
 One of my favorite themes is [Night Owl by Sarah Drasner](https://github.com/highlightjs/highlight.js/blob/master/src/styles/night-owl.css).
 For example you could download the CSS file and save it in your Kirby project under `assets/css/hljs-night-owl.css`. Now you just have to include it in your template `<?= css('assets/css/hljs-night-owl.css') ?>`. Alternatively, use a CSS bundler of your choice.
+
+### Line Numbering
+
+If you choose to activate the line numbering option, you will need to include some css style that handle line numbering display.
+
+A basic example using [pseudo-elements](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements) :
+```css
+pre.hljs .code-line {
+  counter-increment: line;
+}
+
+pre.hljs .code-line::before {
+  content: counter(line);
+  display: inline-block;
+  margin-right: 1em;
+  opacity: 0.5;
+}
+```
 
 ## Credits
 

--- a/classes/KirbyExtended/HighlightAdapter.php
+++ b/classes/KirbyExtended/HighlightAdapter.php
@@ -72,6 +72,13 @@ class HighlightAdapter
                 $highlightedCode = $highlighter->highlightAuto($code);
             }
 
+            // Line numbering
+            if (option('kirby-extended.highlighter.line-numbering', false)) {
+                $lines = preg_split('/\R/', $highlightedCode->value);
+                $lineClass = option('kirby-extended.highlighter.line-numbering-class', 'code-line');
+                $highlightedCode->value = '<span class="' . $lineClass . '">' . implode("</span>\n<span class=\"$lineClass\">", $lines) . '</span>';
+            }
+
             // Append highlighted wrapped in `code` block to parent `pre`
             $codeNode = $dom->createDocumentFragment();
             $codeNode->appendXML('<code>' . $highlightedCode->value . '</code>');


### PR DESCRIPTION
I implemented line numbering support as discussed in #6 using kirby options. 
I added 2 options : 
- kirby-extended.highlighter.line-numbering
- kirby-extended.highlighter.line-numbering-class

I don't know if it is really useful to implement the options because it does not change the style unless you add custom CSS style to display lines ...
Because highlight.php/highlight.js don't support it by default I think using kirby options is a safe choice.

<img width="725" alt="Screenshot 2021-04-10 at 12 26 01" src="https://user-images.githubusercontent.com/25453942/114362394-92b9dd80-9b77-11eb-8236-bc29747a51bd.png">
