### PR TITLE
Feature/code data language attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ To enable automatic language detection, set:
 | `kirby-extended.highlighter.class` | `hljs` | Style class for Highlight to be added to the `pre` element. |
 | `kirby-extended.highlighter.autodetect` | `false` | Indicates if the library should define which language thinks is best. Only applies when no language was set on the KirbyText code block. |
 | `kirby-extended.highlighter.languages` | `[]` | Array of language names to be auto-detected. If empty, every language will be auto-detectable. |
+|`kirby-extended.highlighter.line-numbering` | `false` | Indicates if the library should split up the highlighted code on each new line and wrap each line with a `<span>` element. |
+|`kirby-extended.highlighter.line-numbering-class` | `code-line` | Style class applied to highlighted code line `<span>` elements.|
 
 ## Styling in the frontend
 
@@ -81,6 +83,24 @@ The CSS files over at the repository are maintained and new ones arrive from tim
 
 One of my favorite themes is [Night Owl by Sarah Drasner](https://github.com/highlightjs/highlight.js/blob/master/src/styles/night-owl.css).
 For example you could download the CSS file and save it in your Kirby project under `assets/css/hljs-night-owl.css`. Now you just have to include it in your template `<?= css('assets/css/hljs-night-owl.css') ?>`. Alternatively, use a CSS bundler of your choice.
+
+### Line Numbering
+
+If you choose to activate the line numbering option, you will need to include some css style that handle line numbering display.
+
+A basic example using [pseudo-elements](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements) :
+```css
+pre.hljs .code-line {
+  counter-increment: line;
+}
+
+pre.hljs .code-line::before {
+  content: counter(line);
+  display: inline-block;
+  margin-right: 1em;
+  opacity: 0.5;
+}
+```
 
 ## Credits
 

--- a/classes/KirbyExtended/HighlightAdapter.php
+++ b/classes/KirbyExtended/HighlightAdapter.php
@@ -72,6 +72,13 @@ class HighlightAdapter
                 $highlightedCode = $highlighter->highlightAuto($code);
             }
 
+            // Line numbering
+            if (option('kirby-extended.highlighter.line-numbering', false)) {
+                $lines = preg_split('/\R/', $highlightedCode->value);
+                $lineClass = option('kirby-extended.highlighter.line-numbering-class', 'code-line');
+                $highlightedCode->value = '<span class="' . $lineClass . '">' . implode("</span>\n<span class=\"$lineClass\">", $lines) . '</span>';
+            }
+
             // Append highlighted wrapped in `code` block to parent `pre`
             $codeNode = $dom->createDocumentFragment();
             $codeNode->appendXML('<code>' . $highlightedCode->value . '</code>');

--- a/classes/KirbyExtended/HighlightAdapter.php
+++ b/classes/KirbyExtended/HighlightAdapter.php
@@ -81,7 +81,7 @@ class HighlightAdapter
 
             // Append highlighted wrapped in `code` block to parent `pre`
             $codeNode = $dom->createDocumentFragment();
-            $codeNode->appendXML('<code>' . $highlightedCode->value . '</code>');
+            $codeNode->appendXML('<code data-language="'. $language.'">' . $highlightedCode->value . '</code>');
             $preNode->appendChild($codeNode);
         }
 


### PR DESCRIPTION
Simple data attribute added to code tag name data-language, so it can be displayed in the code block using pseudo CSS style.

```css
pre.hljs > code::before {
  content: attr(data-language);
  float: right;
  opacity: 0.5;
}
```
Tell me if I should mention it in the README

<img width="725" alt="Screenshot 2021-04-10 at 12 26 01" src="https://user-images.githubusercontent.com/25453942/114362514-b41ac980-9b77-11eb-916a-b26e83cc4ba3.png">
