### PR TITLE
Add return type declarations for internal methods

### DIFF
--- a/classes/KirbyExtended/HTML5DOMDocument.php
+++ b/classes/KirbyExtended/HTML5DOMDocument.php
@@ -70,6 +70,7 @@ class HTML5DOMDocument extends \DOMDocument
      * @param bool $entities
      * @return string|false
      */
+    #[\ReturnTypeWillChange]
     public function saveHTML(?\DOMNode $node = null, bool $entities = false)
     {
         $html = parent::saveHTML($node);


### PR DESCRIPTION
https://wiki.php.net/rfc/internal_method_return_types

> Unfortunately, union return types impose a compatibility challenge for libraries: as this construct is only supported since PHP 8.0, libraries would have to accept the fact by default that their code triggers E_DEPRECATED notices on PHP 8.1 if they also want to support PHP versions below 8.0. As a remedy, this RFC proposes to add a ReturnTypeWillChange attribute which could be used to suppress the related E_DEPRECATED notices. Thanks to the backward compatible syntax of attributes, this can be done in code which is compatible with PHP 7 and below. 