### PR TITLE
fix: deprecated mb_convert_encoding()

### DIFF
--- a/classes/JohannSchopplich/HTML5DOMDocument.php
+++ b/classes/JohannSchopplich/HTML5DOMDocument.php
@@ -40,7 +40,7 @@ class HTML5DOMDocument extends \DOMDocument
         // told otherwise, so translate anything above the ASCII range into
         // its html entity equivalent
         // @see https://stackoverflow.com/questions/39148170/utf-8-with-php-domdocument-loadhtml
-        $convertedSource = htmlentities($source, ENT_COMPAT | ENT_HTML401, 'UTF-8');
+        $convertedSource = htmlspecialchars_decode(htmlentities($source, ENT_COMPAT, 'UTF-8'), ENT_QUOTES);
 
         // Add fake root element for XML parser because it assumes that the
         // first encountered tag is the root element

--- a/classes/JohannSchopplich/HTML5DOMDocument.php
+++ b/classes/JohannSchopplich/HTML5DOMDocument.php
@@ -40,7 +40,7 @@ class HTML5DOMDocument extends \DOMDocument
         // told otherwise, so translate anything above the ASCII range into
         // its html entity equivalent
         // @see https://stackoverflow.com/questions/39148170/utf-8-with-php-domdocument-loadhtml
-        $convertedSource = mb_convert_encoding($source, 'HTML-ENTITIES', 'UTF-8');
+        $convertedSource = htmlentities($source, ENT_COMPAT | ENT_HTML401, 'UTF-8');
 
         // Add fake root element for XML parser because it assumes that the
         // first encountered tag is the root element


### PR DESCRIPTION
Hi @johannschopplich,

On PHP 8.2, the plugin throws a deprecated error:
`mb_convert_encoding(): Handling HTML entities via mbstring is deprecated`

I found that using the `htmlentities()` achieves the same result and works as expected.

In addition, you could use `htmlspecialchars()` that only converts specific characters, not sure what would be the best fit for this.
